### PR TITLE
bug fixed for macos m1 when build with `-build=arm64-apple-darwin` failed

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -246,6 +246,7 @@ parse.c:	$(TOP)/src/parse.y lemon
 #
 config.h:	
 	echo '#include <stdio.h>' >temp.c
+	echo '#include <stdlib.h>' >>temp.c
 	echo 'int main(){printf(' >>temp.c
 	echo '"#define SQLITE_PTR_SZ %d",sizeof(char*));' >>temp.c
 	echo 'exit(0);}' >>temp.c

--- a/main.mk
+++ b/main.mk
@@ -214,6 +214,7 @@ parse.c:	$(TOP)/src/parse.y lemon
 #
 config.h:	
 	echo '#include <stdio.h>' >temp.c
+	echo '#include <stdlib.h>' >>temp.c
 	echo 'int main(){printf(' >>temp.c
 	echo '"#define SQLITE_PTR_SZ %d",sizeof(char*));' >>temp.c
 	echo 'exit(0);}' >>temp.c

--- a/tool/lemon.c
+++ b/tool/lemon.c
@@ -7,6 +7,7 @@
 ** The author of this program disclaims copyright.
 */
 #include <stdio.h>
+#include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
 #include <ctype.h>


### PR DESCRIPTION
When I type this command `../configure -build=arm64-apple-darwin`, it shows a error below:
```bash
gcc -g -O2 -o lemon ../tool/lemon.c
../tool/lemon.c:345:7: error: call to undeclared library function 'exit' with type 'void (int) __attribute__((noreturn))'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
      exit(1);
      ^
../tool/lemon.c:345:7: note: include the header <stdlib.h> or explicitly provide a declaration for 'exit'
```

The hint shows that header `stdlib.h` is needed. 

